### PR TITLE
Handful of updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,9 +6,9 @@ signed_ssh_keyfiles:
   - /etc/ssh/ssh_host_ed25519_key
 signed_ssh_hostnames:
   - localhost
-  - "{{ansible_fqdn}}"
-  - "{{ansible_fqdn.split('.')[0]}}"
-  - "{{'.'.join(ansible_fqdn.split('.')[:2])}}"
+  - "{{ ansible_fqdn }}"
+  - "{{ ansible_fqdn.split('.')[0] }}"
+  - "{{ '.'.join(ansible_fqdn.split('.')[:2]) }}"
 signed_ssh_valid_time: +520w
 signed_ssh_certificate_identity: ssh_signed_hostkeys
 signed_ssh_nuke_existing_sigs: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ signed_ssh_valid_time: +520w
 signed_ssh_certificate_identity: ssh_signed_hostkeys
 signed_ssh_nuke_existing_sigs: false
 signed_ssh_service_name: "{{ 'ssh' if ansible_distribution == 'Debian' else 'sshd' }}"
+ssh_signed_ca_keypath: "ca_key"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ signed_ssh_hostnames:
 signed_ssh_valid_time: +520w
 signed_ssh_certificate_identity: ssh_signed_hostkeys
 signed_ssh_nuke_existing_sigs: false
+signed_ssh_service_name: "{{ 'ssh' if ansible_distribution == 'Debian' else 'sshd' }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,15 +2,7 @@
 - name: Restart SSH
   become: true
   ansible.builtin.service:
-    name: ssh
-    state: restarted
-  tags:
-    - ssh_signed_hostkeys
-
-- name: Restart SSH
-  become: true
-  ansible.builtin.service:
-    name: ssh
+    name: "{{ signed_ssh_service_name }}"
     state: restarted
   tags:
     - ssh_signed_hostkeys

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Restart SSH
+  become: true
   ansible.builtin.service:
     name: ssh
     state: restarted
@@ -7,6 +8,7 @@
     - ssh_signed_hostkeys
 
 - name: Restart SSH
+  become: true
   ansible.builtin.service:
     name: ssh
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,17 +4,17 @@ galaxy_info:
   description: Sign SSH host keys using vault-encrypted CA key.
   license: BSD
 
-  min_ansible_version: 1.6
+  min_ansible_version: "1.6"
   platforms:
-  - name: Ubuntu
-    versions:
-      - xenial
-      - bionic
-  - name: Debian
-    versions:
-      - jessie
-      - stretch
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
   galaxy_tags:
-      - system
-      - ssh
+    - system
+    - ssh
 dependencies: []

--- a/tasks/check_cert.yml
+++ b/tasks/check_cert.yml
@@ -1,16 +1,16 @@
 ---
 - name: Test if cert exists
-  stat:
-    path: "{{signed_ssh_keyfile}}-cert.pub"
+  ansible.builtin.stat:
+    path: "{{ signed_ssh_keyfile }}-cert.pub"
   register: signed_ssh_cert_stat
-  check_mode: no
+  check_mode: false
   tags:
     - ssh_signed_hostkeys
 
 - name: Sign certificate
-  include_tasks: sign.yml
+  ansible.builtin.include_tasks: sign.yml
   when: signed_ssh_cert_stat is defined and not signed_ssh_cert_stat.stat.exists
   vars:
-     signed_ssh_certfile: "{{signed_ssh_keyfile}}-cert.pub"
+    signed_ssh_certfile: "{{ signed_ssh_keyfile }}-cert.pub"
   tags:
     - ssh_signed_hostkeys

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,29 +2,29 @@
 #  For re-signing keys when more names have been added
 #  --extra-vars 'signed_ssh_nuke_existing_sigs=true'
 - name: Nuke existing sigs
-  file:
-    path: "{{item}}-cert.pub"
+  ansible.builtin.file:
+    path: "{{ item }}-cert.pub"
     state: absent
   when: signed_ssh_nuke_existing_sigs
-  with_items: "{{signed_ssh_keyfiles}}"
+  with_items: "{{ signed_ssh_keyfiles }}"
   tags:
     - ssh_signed_hostkeys
 
 - name: Test if keyfile exists
-  stat:
-    path: "{{item}}.pub"
+  ansible.builtin.stat:
+    path: "{{ item }}.pub"
   register: signed_ssh_key_stat
-  check_mode: no
-  with_items: "{{signed_ssh_keyfiles}}"
+  check_mode: false
+  with_items: "{{ signed_ssh_keyfiles }}"
   tags:
     - ssh_signed_hostkeys
 
 - name: Check cert
-  include_tasks: check_cert.yml
+  ansible.builtin.include_tasks: check_cert.yml
   when: signed_ssh_key_stat is defined and signed_ssh_stat_keyfile.stat.exists
-  with_items: "{{signed_ssh_key_stat.results}}"
+  with_items: "{{ signed_ssh_key_stat.results }}"
   vars:
-    signed_ssh_keyfile: "{{signed_ssh_stat_keyfile.item}}"
+    signed_ssh_keyfile: "{{ signed_ssh_stat_keyfile.item }}"
   loop_control:
     loop_var: signed_ssh_stat_keyfile
   tags:

--- a/tasks/sign.yml
+++ b/tasks/sign.yml
@@ -10,7 +10,7 @@
 - name: Decrypt signing key
   become: true
   ansible.builtin.copy:
-    src: ca_key
+    src: "{{ ssh_signed_ca_keypath }}"
     dest: "{{ ssh_signed_tempfile.path }}"
     owner: root
     group: root

--- a/tasks/sign.yml
+++ b/tasks/sign.yml
@@ -8,6 +8,7 @@
     - ssh_signed_hostkeys
 
 - name: Decrypt signing key
+  become: true
   ansible.builtin.copy:
     src: ca_key
     dest: "{{ ssh_signed_tempfile.path }}"
@@ -18,11 +19,13 @@
     - ssh_signed_hostkeys
 
 - name: Sign key
+  become: true
   ansible.builtin.command: "ssh-keygen -s {{ ssh_signed_tempfile.path }} -I {{ signed_ssh_certificate_identity }} -h -n {{ ','.join(signed_ssh_hostnames) }} -V {{ signed_ssh_valid_time }} {{ signed_ssh_certfile.rstrip('-cert.pub') }}"
   tags:
     - ssh_signed_hostkeys
 
 - name: File permissions
+  become: true
   ansible.builtin.file:
     path: "{{ signed_ssh_certfile }}"
     owner: root
@@ -32,6 +35,7 @@
     - ssh_signed_hostkeys
 
 - name: Add cert to sshd_config
+  become: true
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     line: "HostCertificate {{ signed_ssh_certfile }}"
@@ -41,6 +45,7 @@
     - ssh_signed_hostkeys
 
 - name: Remove signing cert
+  become: true
   ansible.builtin.file:
     path: "{{ ssh_signed_tempfile.path }}"
     state: absent

--- a/tasks/sign.yml
+++ b/tasks/sign.yml
@@ -1,6 +1,6 @@
 ---
 - name: Make tempfile
-  tempfile:
+  ansible.builtin.tempfile:
     state: file
     suffix: signed_hostkeys
   register: ssh_signed_tempfile
@@ -8,9 +8,9 @@
     - ssh_signed_hostkeys
 
 - name: Decrypt signing key
-  copy:
+  ansible.builtin.copy:
     src: ca_key
-    dest: "{{ssh_signed_tempfile.path}}"
+    dest: "{{ ssh_signed_tempfile.path }}"
     owner: root
     group: root
     mode: a=-,u+r
@@ -18,13 +18,13 @@
     - ssh_signed_hostkeys
 
 - name: Sign key
-  command: "ssh-keygen -s {{ssh_signed_tempfile.path}} -I {{signed_ssh_certificate_identity}} -h -n {{','.join(signed_ssh_hostnames)}} -V {{signed_ssh_valid_time}} {{signed_ssh_certfile.rstrip('-cert.pub')}}"
+  ansible.builtin.command: "ssh-keygen -s {{ ssh_signed_tempfile.path }} -I {{ signed_ssh_certificate_identity }} -h -n {{ ','.join(signed_ssh_hostnames) }} -V {{ signed_ssh_valid_time }} {{ signed_ssh_certfile.rstrip('-cert.pub') }}"
   tags:
     - ssh_signed_hostkeys
 
 - name: File permissions
-  file:
-    path: "{{signed_ssh_certfile}}"
+  ansible.builtin.file:
+    path: "{{ signed_ssh_certfile }}"
     owner: root
     group: root
     mode: a=r,u+w
@@ -32,17 +32,17 @@
     - ssh_signed_hostkeys
 
 - name: Add cert to sshd_config
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
-    line: "HostCertificate {{signed_ssh_certfile}}"
-    regexp: "HostCertificate {{signed_ssh_certfile}}"
+    line: "HostCertificate {{ signed_ssh_certfile }}"
+    regexp: "HostCertificate {{ signed_ssh_certfile }}"
   notify: Restart SSH
   tags:
     - ssh_signed_hostkeys
 
 - name: Remove signing cert
-  file:
-    path: "{{ssh_signed_tempfile.path}}"
+  ansible.builtin.file:
+    path: "{{ ssh_signed_tempfile.path }}"
     state: absent
   tags:
     - ssh_signed_hostkeys


### PR DESCRIPTION
Some functionality changes and I ran ansible-lint against it and made corrections.

Summary:
- Made the CA file location a variable, this should let you use it as a separate role without changing the files in the role itself. 
- Updated the SSH handler to support sshd and ssh services
- Added `become` to the tasks that were requiring it, now it can be used without needing to run the whole thing as root